### PR TITLE
Fix a bug

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -812,7 +812,7 @@ class MainWindow(QMainWindow, WindowMixin):
             self.loadFile(filename)
 
     def scanAllImages(self, folderPath):
-        extensions = {'.jpeg','.jpg', '.png', '.bmp'}
+        extensions = ['.jpeg','.jpg', '.png', '.bmp']
         images = []
 
         for root, dirs, files in os.walk(folderPath):


### PR DESCRIPTION
when run :./labelImg.py
Error: 
  File "./labelImg.py", line 815
    extensions = {'.jpeg','.jpg', '.png', '.bmp'}
Fix:
 change {'.jpeg','.jpg', '.png', '.bmp'} to ['.jpeg','.jpg', '.png', '.bmp']
Environment：python=2.6.9   qt=4.11.3 OX=mac os