### PR TITLE
py3 removes sys.maxint, float(inf) works in py2/py3

### DIFF
--- a/libs/labelFile.py
+++ b/libs/labelFile.py
@@ -53,10 +53,10 @@ class LabelFile(object):
 
     @staticmethod
     def convertPoints2BndBox(points):
-        xmin = sys.maxint
-        ymin = sys.maxint
-        xmax = -sys.maxint
-        ymax = -sys.maxint
+        xmin = float('inf')
+        ymin = float('inf')
+        xmax = float('-inf')
+        ymax = float('-inf')
         for p in points:
             x = p[0]
             y = p[1]


### PR DESCRIPTION
i'd like to prep the code to support py3 and qt5, this is a safe start