### PR TITLE
Set focus on image canvas after image is loaded

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -807,6 +807,7 @@ class MainWindow(QMainWindow, WindowMixin):
                 xmlPath = os.path.join(self.defaultSaveDir, basename)
                 self.loadPascalXMLByFilename(xmlPath)
 
+            self.canvas.setFocus()
             return True
         return False
 


### PR DESCRIPTION
On Mac with py3 and pyqt5 after a new image is loaded focus appears on zoom widget. This PR fixes this issue.