### PR TITLE
fix some bugs when running on Mac with PyQT5

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -204,7 +204,7 @@ class MainWindow(QMainWindow, WindowMixin):
                                'Ctrl+r', 'open', u'Change default saved Annotation dir')
 
         openAnnotation = action('&Open Annotation', self.openAnnotation,
-                                'Ctrl+q', 'openAnnotation', u'Open Annotation')
+                                'Ctrl+Shift+O', 'openAnnotation', u'Open Annotation')
 
         openNextImg = action('&Next Image', self.openNextImg,
                              'd', 'next', u'Open Next')

--- a/labelImg.py
+++ b/labelImg.py
@@ -442,7 +442,7 @@ class MainWindow(QMainWindow, WindowMixin):
         self.updateFileMenu()
         # Since loading the file may take some time, make sure it runs in the
         # background.
-        self.queueEvent(partial(self.loadFile, self.filePath))
+        self.queueEvent(partial(self.loadFile, self.filePath or ""))
 
         # Callbacks:
         self.zoomWidget.valueChanged.connect(self.paintCanvas)
@@ -1014,13 +1014,14 @@ class MainWindow(QMainWindow, WindowMixin):
             return
         path = os.path.dirname(str(self.filePath))\
             if self.filePath else '.'
-        formats = ['*.%s' % str(fmt).lower()
-                   for fmt in QImageReader.supportedImageFormats()]
+        formats = ['*.%s' % fmt.data().decode("ascii").lower() for fmt in QImageReader.supportedImageFormats()]
         filters = "Image & Label files (%s)" % \
             ' '.join(formats + ['*%s' % LabelFile.suffix])
         filename = QFileDialog.getOpenFileName(self,
                                                '%s - Choose Image or Label file' % __appname__, path, filters)
         if filename:
+            if isinstance(filename, (tuple,list)):
+                filename=filename[0]
             self.loadFile(filename)
 
     def saveFile(self, _value=False):

--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -525,16 +525,12 @@ class Canvas(QWidget):
             h_delta = delta.x()
             v_delta = delta.y()
 
-        if v_delta:
-            mods = ev.modifiers()
-            if Qt.ControlModifier == int(mods):
-                self.zoomRequest.emit(v_delta)
-            else:
-                self.scrollRequest.emit(v_delta,
-                                        Qt.Horizontal if (Qt.ShiftModifier == int(mods))
-                                        else Qt.Vertical)
+        mods = ev.modifiers()
+        if Qt.ControlModifier == int(mods) and v_delta:
+            self.zoomRequest.emit(v_delta)
         else:
-            self.scrollRequest.emit(h_delta, Qt.Horizontal)
+            v_delta and self.scrollRequest.emit(v_delta, Qt.Vertical)
+            h_delta and self.scrollRequest.emit(h_delta, Qt.Horizontal)
         ev.accept()
 
     def keyPressEvent(self, ev):

--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -512,16 +512,29 @@ class Canvas(QWidget):
         return super(Canvas, self).minimumSizeHint()
 
     def wheelEvent(self, ev):
-        if ev.orientation() == Qt.Vertical:
+        qt_version = 4 if hasattr(ev, "delta") else 5
+        if qt_version == 4:
+            if ev.orientation() == Qt.Vertical:
+                v_delta = ev.delta()
+                h_delta = 0
+            else:
+                h_delta = ev.delta()
+                v_delta = 0
+        else:
+            delta = ev.angleDelta()
+            h_delta = delta.x()
+            v_delta = delta.y()
+
+        if v_delta:
             mods = ev.modifiers()
             if Qt.ControlModifier == int(mods):
-                self.zoomRequest.emit(ev.delta())
+                self.zoomRequest.emit(v_delta)
             else:
-                self.scrollRequest.emit(ev.delta(),
+                self.scrollRequest.emit(v_delta,
                                         Qt.Horizontal if (Qt.ShiftModifier == int(mods))
                                         else Qt.Vertical)
         else:
-            self.scrollRequest.emit(ev.delta(), Qt.Horizontal)
+            self.scrollRequest.emit(h_delta, Qt.Horizontal)
         ev.accept()
 
     def keyPressEvent(self, ev):


### PR DESCRIPTION
[FIX]move hot key for open annotation from ctrl+q to Ctrl+Shift+O to avoid collision with Mac universal application quit key Command+Q

[FIX]when startup without specify a image, self.filePath will be None, but when loadFile get it with self.queueEvent partial, the filePath will turn into 'None', so if there real is a img name as None, it will open it unexpectedly

[FIX]when open file, QImageReader.supportedImageFormats() gives items in QbyteArray type, so if do str(fmt) will gives b'bmp' so that open prompt will not be able to open anything.

[FIX]in PyQT5, QFileDialog.getOpenFileName returns a tuple with (filename, filters), not filename alone.
