### PR TITLE
Fix moving RectBox with right click

### DIFF
--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -222,9 +222,7 @@ class Canvas(QWidget):
             self.selectedShape = shape
             self.repaint()
         else:
-            shape.label = self.selectedShape.label
-            self.deleteSelected()
-            self.shapes.append(shape)
+            self.selectedShape.points = [p for p in shape.points]
         self.selectedShapeCopy = None
 
     def hideBackroundShapes(self, value):


### PR DESCRIPTION
Hi I found a bug when moving a RectBox with the right mouse button.
Steps to reproduce:
- Create new RectBox
- Hold right mouse button and drag RectBox to another position
- Select "Move here" from the context menu
- The moved RectBox is now out of sync with the item list. On windows the program crashes, if you try to select the moved RectBox

Problem:
When the RectBox is moved the old RectBox is deleted and the temporary copy is selected. However the shapesToItems does not get updated. 

Fix:
Move the original RectBox and remove the temporary copy.