### PR TITLE
Changed .lif to .xml, allowing annotation I/O

### DIFF
--- a/libs/labelFile.py
+++ b/libs/labelFile.py
@@ -18,7 +18,7 @@ class LabelFileError(Exception):
 
 class LabelFile(object):
     # It might be changed as window creates
-    suffix = '.lif'
+    suffix = '.xml'
 
     def __init__(self, filename=None):
         self.shapes = ()


### PR DESCRIPTION
Currently (5/30/17) on Ubuntu 16.04, the .lif extension causes the app to be fundamentally unusable:
-Upon opening, reopening, or navigating within the application to a previously annotated image, previous annotations cannot be loaded or edited

Saving the annotations as .xml allows the annotations to be read when switching between images or reopening previously annotated images. See the edit above for the exact location of the change.