### PR TITLE
Zooming in on cursor

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -181,6 +181,7 @@ class MainWindow(QMainWindow, WindowMixin):
             Qt.Vertical: scroll.verticalScrollBar(),
             Qt.Horizontal: scroll.horizontalScrollBar()
         }
+        self.scrollArea = scroll
         self.canvas.scrollRequest.connect(self.scrollRequest)
 
         self.canvas.newShape.connect(self.newShape)
@@ -805,9 +806,55 @@ class MainWindow(QMainWindow, WindowMixin):
         self.setZoom(self.zoomWidget.value() + increment)
 
     def zoomRequest(self, delta):
+        # get the current scrollbar positions
+        # calculate the percentages ~ coordinates
+        h_bar = self.scrollBars[Qt.Horizontal]
+        v_bar = self.scrollBars[Qt.Vertical]
+
+        # get the current maximum, to know the difference after zooming
+        h_bar_max = h_bar.maximum()
+        v_bar_max = v_bar.maximum()
+
+        # get the cursor position and canvas size
+        # calculate the desired movement from 0 to 1
+        # where 0 = move left
+        #       1 = move right
+        # up and down analogous
+        cursor = QCursor()
+        pos = cursor.pos()
+
+        cursor_x = pos.x()
+        cursor_y = pos.y()
+
+        w = self.canvas.width()
+        h = self.canvas.height()
+
+        w = self.scrollArea.width()
+        h = self.scrollArea.height()
+
+        print("current: ")
+        print(cursor_x, cursor_y)
+        print(w, h)
+        print()
+
+        margin = 0.1
+        move_x = (cursor_x - margin * w) / (w - 2 * margin * w)
+        move_y = (cursor_y - margin * h) / (h - 2 * margin * h)
+
+        # zoom in
         units = delta / (8 * 15)
         scale = 10
         self.addZoom(scale * units)
+
+        d_h_bar_max = h_bar.maximum() - h_bar_max
+        d_v_bar_max = v_bar.maximum() - v_bar_max
+
+        # get the new scrollbar values
+        new_h_bar_value = h_bar.value() + move_x * d_h_bar_max
+        new_v_bar_value = v_bar.value() + move_y * d_v_bar_max
+
+        h_bar.setValue(new_h_bar_value)
+        v_bar.setValue(new_v_bar_value)
 
     def setFitWindow(self, value=True):
         if value:

--- a/labelImg.py
+++ b/labelImg.py
@@ -826,26 +826,26 @@ class MainWindow(QMainWindow, WindowMixin):
         cursor_x = pos.x()
         cursor_y = pos.y()
 
-        w = self.canvas.width()
-        h = self.canvas.height()
-
         w = self.scrollArea.width()
         h = self.scrollArea.height()
 
-        print("current: ")
-        print(cursor_x, cursor_y)
-        print(w, h)
-        print()
-
+        # the scaling from 0 to 1 has some padding
+        # you don't have to hit the very leftmost pixel for a maximum-left movement
         margin = 0.1
         move_x = (cursor_x - margin * w) / (w - 2 * margin * w)
         move_y = (cursor_y - margin * h) / (h - 2 * margin * h)
+
+        # clamp the values form 0 to 1
+        move_x = min(max(move_x, 0), 1)
+        move_y = min(max(move_y, 0), 1)
 
         # zoom in
         units = delta / (8 * 15)
         scale = 10
         self.addZoom(scale * units)
 
+        # get the difference in scrollbar values
+        # this is how far we can move
         d_h_bar_max = h_bar.maximum() - h_bar_max
         d_v_bar_max = v_bar.maximum() - v_bar_max
 


### PR DESCRIPTION
So far, zooming in is centered on the upper left corner.

With this pull-request, the zoom centers on the cursor.
This allows you to zoom in on specific objects.

Tested only on the pyqt5 bindings and on windows 10.
But this should work across versions.