### PR TITLE
Encode 2 byte charactor

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -430,8 +430,6 @@ class MainWindow(QMainWindow, WindowMixin):
         self.move(position)
         saveDir = ustr(settings.get('savedir', None))
         self.lastOpenDir = ustr(settings.get('lastOpenDir', None))
-        # fix bug
-        saveDir = None
         if saveDir is not None and os.path.exists(saveDir):
             self.defaultSaveDir = saveDir
             self.statusBar().showMessage('%s started. Annotation will be saved to %s' %

--- a/libs/pascal_voc_io.py
+++ b/libs/pascal_voc_io.py
@@ -27,7 +27,7 @@ class PascalVocWriter:
         """
         rough_string = ElementTree.tostring(elem, 'utf8')
         root = etree.fromstring(rough_string)
-        return etree.tostring(root, pretty_print=True)
+        return etree.tostring(root, pretty_print=True, encoding='UTF-8')
 
     def genXML(self):
         """


### PR DESCRIPTION
xml file content does not encode to 2byte character.
So I add encode option to etree.tostring.
