### PR TITLE
Fixed possible typo in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ testpy3:
 
 qt4: qt4py2
 
-qt5: qt4py3
+qt5: qt5py3
 
 qt4py2:
 	pyrcc4 -py2 -o resources.py resources.qrc


### PR DESCRIPTION
Fixed typo in makefile, so that "make qt5" will now actually use qt5: "pyrcc5 -o resources.py resources.qrc".

Bug: "make qt5" installed qt4py2. That is kind of miss leading, since "qt5" should actually use qt5 and not use qt4.