### PR TITLE
Fixed usage of deprecated function

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -942,7 +942,7 @@ class MainWindow(QMainWindow, WindowMixin):
             # Default : select last item if there is at least one item
             if self.labelList.count():
                 self.labelList.setCurrentItem(self.labelList.item(self.labelList.count()-1))
-                self.labelList.setItemSelected(self.labelList.item(self.labelList.count()-1), True)
+                self.labelList.item(self.labelList.count()-1).setSelected(True)
 
             self.canvas.setFocus(True)
             return True


### PR DESCRIPTION
Hi, I've just found and installed your tool (using qt5py3). I had a problem with application crashing, when using "Previous image" function. I tracked down the error to labelImg.py line 945, where obsolete (in qt5 deprecated function) setItemSelected had been used. I have used proposed substitute function setSelected (it should work with qt 4.2+).

PS: this is my first pull request so i hope it is ok
PPS: the tool is cool, thanks for sharing it with others