### PR TITLE
Add option to reopen an label file to save it again

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -551,9 +551,9 @@ class MainWindow(QMainWindow, WindowMixin):
 
     def addRecentFile(self, filePath):
         if filePath in self.recentFiles:
-            self.recentFiles.remove(filePath)
+            self.recentFiles.removeAt(self.recentFiles.indexOf(filePath))
         elif len(self.recentFiles) >= self.maxRecent:
-            self.recentFiles.pop()
+            self.recentFiles.removeAt(self.recentFiles.count() - 1)
         self.recentFiles.insert(0, filePath)
 
     def beginner(self):
@@ -910,9 +910,20 @@ class MainWindow(QMainWindow, WindowMixin):
                                       % (e, unicodeFilePath))
                     self.status("Error reading %s" % unicodeFilePath)
                     return False
-                self.imageData = self.labelFile.imageData
-                self.lineColor = QColor(*self.labelFile.lineColor)
-                self.fillColor = QColor(*self.labelFile.fillColor)
+
+                # Label xml file and show bound box according to its filename
+                if self.usingPascalVocFormat is True:
+                    if self.defaultSaveDir is not None:
+                        basename = os.path.basename(
+                            os.path.splitext(self.filePath)[0]) + XML_EXT
+                        xmlPath = os.path.join(self.defaultSaveDir, basename)
+                        self.loadPascalXMLByFilename(xmlPath)
+                    else:
+                        xmlPath = os.path.splitext(str(filePath))[0] + XML_EXT
+
+                        if os.path.isfile(xmlPath):
+                            self.loadPascalXMLByFilename(xmlPath)
+                        unicodeFilePath = self.labelFile.imagePath
             else:
                 # Load image:
                 # read data first and store for saving into label file.
@@ -936,18 +947,6 @@ class MainWindow(QMainWindow, WindowMixin):
             self.paintCanvas()
             self.addRecentFile(self.filePath)
             self.toggleActions(True)
-
-            # Label xml file and show bound box according to its filename
-            if self.usingPascalVocFormat is True:
-                if self.defaultSaveDir is not None:
-                    basename = os.path.basename(
-                        os.path.splitext(self.filePath)[0]) + XML_EXT
-                    xmlPath = os.path.join(self.defaultSaveDir, basename)
-                    self.loadPascalXMLByFilename(xmlPath)
-                else:
-                    xmlPath = os.path.splitext(filePath)[0] + XML_EXT
-                    if os.path.isfile(xmlPath):
-                        self.loadPascalXMLByFilename(xmlPath)
 
             self.setWindowTitle(__appname__ + ' ' + filePath)
 
@@ -1170,7 +1169,9 @@ class MainWindow(QMainWindow, WindowMixin):
             self.loadFile(filename)
 
     def saveFile(self, _value=False):
-        if self.defaultSaveDir is not None and len(ustr(self.defaultSaveDir)):
+        if self.labelFile is not None and self.labelFile.originalFileName is not None:
+            self._saveFile(self.labelFile.originalFileName)
+        elif self.defaultSaveDir is not None and len(ustr(self.defaultSaveDir)):
             if self.filePath:
                 imgFileName = os.path.basename(self.filePath)
                 savedFileName = os.path.splitext(imgFileName)[0] + XML_EXT
@@ -1294,14 +1295,15 @@ class MainWindow(QMainWindow, WindowMixin):
                         self.labelHist.append(line)
 
     def loadPascalXMLByFilename(self, xmlPath):
-        if self.filePath is None:
-            return
         if os.path.isfile(xmlPath) is False:
             return
 
         tVocParseReader = PascalVocReader(xmlPath)
-        shapes = tVocParseReader.getShapes()
-        self.loadLabels(shapes)
+        self.filePath = tVocParseReader.imagepath
+        self.imageData = read(tVocParseReader.imagepath)
+        self.labelFile.originalFileName = tVocParseReader.filepath
+        self.labelFile.shapes = tVocParseReader.getShapes()
+        self.labelFile.imagePath = tVocParseReader.imagepath
         self.canvas.verified = tVocParseReader.verified
 
 

--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -71,7 +71,7 @@ class Canvas(QWidget):
         self.restoreCursor()
 
     def isVisible(self, shape):
-        return self.visible.get(shape, True)
+        return shape in self.visible
 
     def drawing(self):
         return self.mode == self.CREATE
@@ -622,6 +622,7 @@ class Canvas(QWidget):
 
     def loadShapes(self, shapes):
         self.shapes = list(shapes)
+        self.visible = list(shapes)
         self.current = None
         self.repaint()
 

--- a/libs/labelFile.py
+++ b/libs/labelFile.py
@@ -24,6 +24,7 @@ class LabelFile(object):
 
     def __init__(self, filename=None):
         self.shapes = ()
+        self.originalFileName = None
         self.imagePath = None
         self.imageData = None
         self.verified = False

--- a/libs/pascal_voc_io.py
+++ b/libs/pascal_voc_io.py
@@ -130,6 +130,7 @@ class PascalVocReader:
     def __init__(self, filepath):
         # shapes type:
         # [labbel, [(x1,y1), (x2,y2), (x3,y3), (x4,y4)], color, color, difficult]
+        self.imagepath = None
         self.shapes = []
         self.filepath = filepath
         self.verified = False
@@ -151,6 +152,7 @@ class PascalVocReader:
         parser = etree.XMLParser(encoding=ENCODE_METHOD)
         xmltree = ElementTree.parse(self.filepath, parser=parser).getroot()
         filename = xmltree.find('filename').text
+        self.imagepath = xmltree.find('path').text
         try:
             verified = xmltree.attrib['verified']
             if verified == 'yes':


### PR DESCRIPTION
Currently it is not possible to reopen a label file. This functionality was originally implemented in an earlier version. This commit reimplement the functionality.

These lines are python2 fixex:
```
self.recentFiles.removeAt(self.recentFiles.indexOf(filePath))
...
self.recentFiles.removeAt(self.recentFiles.count() - 1)
```