### PR TITLE
Enhance compatibility

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 import codecs
 import os.path
 import re


### PR DESCRIPTION
With Anaconda3-4.4.0-Windows-x86_64 in Win 8 & 10, encoding name "utf8" will lead to error.  We change the encoding name to "utf-8", it's OK. Very strange, we do not know why.