### PR TITLE
fix a bug of disabled edit and delete menu in the label list menu

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -573,6 +573,7 @@ class MainWindow(QMainWindow, WindowMixin):
     def setEditMode(self):
         assert self.advanced()
         self.toggleDrawMode(True)
+        self.labelSelectionChanged()
 
     def updateFileMenu(self):
         currFilePath = self.filePath


### PR DESCRIPTION
This fixes a bug that when you select a label in the label list menu in "CREATE" mode, enter "EDIT" mode, and right click the same label (in the label list), the "edit" and "delete" menu are disabled.
Also, this PR will highlight the box if you enter the edit mode with the label selected.


