### PR TITLE
fix a bug to select a small bounding box

### DIFF
--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -283,14 +283,12 @@ class Canvas(QWidget):
         if self.selectedVertex():  # A vertex is marked for selection.
             index, shape = self.hVertex, self.hShape
             shape.highlightVertex(index, shape.MOVE_VERTEX)
+            self.selectShape(shape)
             return
         for shape in reversed(self.shapes):
             if self.isVisible(shape) and shape.containsPoint(point):
-                shape.selected = True
-                self.selectedShape = shape
+                self.selectShape(shape)
                 self.calculateOffsets(shape, point)
-                self.setHiding()
-                self.selectionChanged.emit(True)
                 return
 
     def calculateOffsets(self, shape, point):


### PR DESCRIPTION
This fixes #147.

This PR will enable to select a small box, which was previously prevented because a vertex near the mouse cursor was activated for selection.
You can left-click or right-click (for menus) within a box or one of its vertices to select the box and edit.