### PR TITLE
Fix a bug: creating a box with one point

### DIFF
--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -244,9 +244,6 @@ class Canvas(QWidget):
             self.current.addPoint(QPointF(maxX, minY))
             self.current.addPoint(targetPos)
             self.current.addPoint(QPointF(minX, maxY))
-            self.current.addPoint(initPos)
-            self.current.close()
-            self.line[0] = self.current[-1]
             self.finalise()
         elif not self.outOfPixmap(pos):
             self.current = Shape()
@@ -449,6 +446,12 @@ class Canvas(QWidget):
 
     def finalise(self):
         assert self.current
+        if self.current.points[0] == self.current.points[-1]:
+            self.current = None
+            self.drawingPolygon.emit(False)
+            self.update()
+            return
+
         self.current.close()
         self.shapes.append(self.current)
         self.current = None

--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -245,9 +245,9 @@ class Canvas(QWidget):
             self.current.addPoint(targetPos)
             self.current.addPoint(QPointF(minX, maxY))
             self.current.addPoint(initPos)
+            self.current.close()
             self.line[0] = self.current[-1]
-            if self.current.isClosed():
-                self.finalise()
+            self.finalise()
         elif not self.outOfPixmap(pos):
             self.current = Shape()
             self.current.addPoint(pos)

--- a/libs/shape.py
+++ b/libs/shape.py
@@ -67,9 +67,7 @@ class Shape(object):
         return False
 
     def addPoint(self, point):
-        if self.points and point == self.points[0]:
-            self.close()
-        else:
+        if not self.reachMaxPoints():
             self.points.append(point)
 
     def popPoint(self):


### PR DESCRIPTION
This PR will fix a bug that was possible to create a box with one point, if you single-click without moving a cursor in "Create mode." It wasn't possible to enlarge the zero-sized box by clicking its vertex because it had only one point (also causing an index error), so with this PR a box shape can be changed from the zero size. However, the second commit will prevent from creating a zero-sized box.