### PR TITLE
fix importing of resources

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -24,7 +24,7 @@ except ImportError:
     from PyQt4.QtGui import *
     from PyQt4.QtCore import *
 
-import resources
+from labelImg import resources
 # Add internal libs
 from libs.constants import *
 from libs.lib import struct, newAction, newIcon, addActions, fmtShortcut, generateColorByText


### PR DESCRIPTION
For some reason labelImg does not work for me out of the box when it's installed.  It complains about not finding the resources module. This PR contains a change that made it work for me.