### PR TITLE
Show cursor coordinates in status bar + filepath bugfix

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -176,7 +176,7 @@ class MainWindow(QMainWindow, WindowMixin):
         self.zoomWidget = ZoomWidget()
         self.colorDialog = ColorDialog(parent=self)
 
-        self.canvas = Canvas()
+        self.canvas = Canvas(parent=self)
         self.canvas.zoomRequest.connect(self.zoomRequest)
 
         scroll = QScrollArea()
@@ -456,6 +456,10 @@ class MainWindow(QMainWindow, WindowMixin):
 
         self.populateModeActions()
 
+        # Display cursor coordinates at the right of status bar
+        self.labelCoordinates = QLabel('')
+        self.statusBar().addPermanentWidget(self.labelCoordinates)
+
     ## Support Functions ##
 
     def noShapes(self):
@@ -525,6 +529,7 @@ class MainWindow(QMainWindow, WindowMixin):
         self.imageData = None
         self.labelFile = None
         self.canvas.resetState()
+        self.labelCoordinates.clear()
 
     def currentItem(self):
         items = self.labelList.selectedItems()

--- a/labelImg.py
+++ b/labelImg.py
@@ -888,6 +888,9 @@ class MainWindow(QMainWindow, WindowMixin):
         if filePath is None:
             filePath = self.settings.get(SETTING_FILENAME)
 
+        # Make sure that filePath is a regular python string, rather than QString
+        filePath = str(filePath)
+
         unicodeFilePath = ustr(filePath)
         # Tzutalin 20160906 : Add file list and dock to move faster
         # Highlight the file item

--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -104,6 +104,12 @@ class Canvas(QWidget):
         """Update line with last point and current coordinates."""
         pos = self.transformPos(ev.pos())
 
+        # Update coordinates in status bar if image is opened
+        window = self.parent().window()
+        if window.filePath is not None:
+            self.parent().window().labelCoordinates.setText(
+                'X: %d; Y: %d' % (pos.x(), pos.y()))
+
         # Polygon drawing.
         if self.drawing():
             self.overrideCursor(CURSOR_DRAW)


### PR DESCRIPTION
Something I found difficult in labelImg while annotating images is getting sense of exact dimensions of bounding boxes. For now I made a small change to display X/Y cursor coordinates in lower right window corner, which helps a bit to determine the rectangle dimensions. Also suggested another enhancement in #226.

I was also having the issue described in #189, despite of deleting ~/.labelImgSettings.pkl as suggested - so I added a cast from QString to regular python string, which seems to have solved the problem.