### PR TITLE
Fixed bug in shape.py

### DIFF
--- a/libs/shape.py
+++ b/libs/shape.py
@@ -120,6 +120,8 @@ class Shape(object):
                 font.setPointSize(8)
                 font.setBold(True)
                 painter.setFont(font)
+                if(self.label == None):
+                    self.label = ""
                 painter.drawText(min_x, min_y, self.label)
 
             if self.fill:


### PR DESCRIPTION
Ubuntu 16.04 and Python 2.7

TypeError: arguments did not match any overloaded call:
  QPainter.drawText(QPointF, QString): argument 1 has unexpected type 'float'
  QPainter.drawText(QRectF, int, QString): argument 1 has unexpected type 'float'
  QPainter.drawText(QRect, int, QString): argument 1 has unexpected type 'float'
  QPainter.drawText(QRectF, QString, QTextOption option=QTextOption()): argument 1 has unexpected type 'float'
  QPainter.drawText(QPoint, QString): argument 1 has unexpected type 'float'
  QPainter.drawText(int, int, int, int, int, QString): argument 3 has unexpected type 'NoneType'
  QPainter.drawText(int, int, QString): argument 3 has unexpected type 'NoneType'
QPainter::begin: Painter already active
