### PR TITLE
Allowing all supported extensions (TIFF in Qt 4.8, along with PPM, PBM, and PGM)

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -1040,7 +1040,7 @@ class MainWindow(QMainWindow, WindowMixin):
             self.loadFile(filename)
 
     def scanAllImages(self, folderPath):
-        extensions = ['.jpeg', '.jpg', '.png', '.bmp']
+        extensions = ['.%s' % fmt.data().decode("ascii").lower() for fmt in QImageReader.supportedImageFormats()]
         images = []
 
         for root, dirs, files in os.walk(folderPath):


### PR DESCRIPTION
This PR enables TIFF support for those using Qt 4.8, along with PPM, PBM, and PGM support for all Qt versions.

As mentioned in #174, the `QImageReader` actually supports a number of formats. While the [Qt 4.8 supported formats](http://doc.qt.io/archives/qt-4.8/qimagereader.html#supportedImageFormats) and [Qt 5.x supported formats](http://doc.qt.io/qt-5/qimagereader.html#supportedImageFormats) differ, it is worthwhile to be able to use all of those available for the version in use. This PR implements this change.