### PR TITLE
fix mac python3 qt5 install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,9 +80,10 @@ Python 3 + Qt5 (Works on macOS High Sierra)
 
     brew install qt  # will install qt-5.x.x
     brew install libxml2
+    pip3 install pyqt5 lxml
     make qt5py3
-    python labelImg.py
-    python  labelImg.py [IMAGE_PATH] [PRE-DEFINED CLASS FILE]
+    python3 labelImg.py
+    python3 labelImg.py [IMAGE_PATH] [PRE-DEFINED CLASS FILE]
 
 
 Windows


### PR DESCRIPTION
fix error: 
```
pyrcc5 -o resources.py resources.qrc
make: pyrcc5: No such file or directory
make: *** [qt5py3] Error 1
```

```
ModuleNotFoundError: No module named 'lxml'
```