### PR TITLE
Issue #287: NoneType has no attribute toggleVerify

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -1175,7 +1175,11 @@ class MainWindow(QMainWindow, WindowMixin):
                 # If the labelling file does not exist yet, create if and
                 # re-save it with the verified attribute.
                 self.saveFile()
-                self.labelFile.toggleVerify()
+                try:
+                    self.labelFile.toggleVerify()
+                except AttributeError:
+                    # This occurs if the user cancels the operation
+                    return
 
             self.canvas.verified = self.labelFile.verified
             self.paintCanvas()


### PR DESCRIPTION
Quick fix that prevents a crash when a user tries to cancel the verify window.