### PR TITLE
Fix bug: size is 0 in xml annotations

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -44,6 +44,7 @@ from libs.yolo_io import YoloReader
 from libs.yolo_io import TXT_EXT
 from libs.ustr import ustr
 from libs.version import __version__
+from libs.file_read import read
 
 __appname__ = 'labelImg'
 
@@ -1396,15 +1397,6 @@ class MainWindow(QMainWindow, WindowMixin):
 
 def inverted(color):
     return QColor(*[255 - v for v in color.getRgb()])
-
-
-def read(filename, default=None):
-    try:
-        with open(filename, 'rb') as f:
-            return f.read()
-    except:
-        return default
-
 
 def get_main_app(argv=[]):
     """

--- a/libs/file_read.py
+++ b/libs/file_read.py
@@ -1,0 +1,9 @@
+def read(filename, default=None):
+    '''
+    Read a file into a byte array
+    '''
+    try:
+        with open(filename, 'rb') as f:
+            return f.read()
+    except:
+        return default

--- a/libs/labelFile.py
+++ b/libs/labelFile.py
@@ -10,7 +10,7 @@ from base64 import b64encode, b64decode
 from libs.pascal_voc_io import PascalVocWriter
 from libs.yolo_io import YOLOWriter
 from libs.pascal_voc_io import XML_EXT
-from file_read import read
+from libs.file_read import read
 import os.path
 import sys
 

--- a/libs/labelFile.py
+++ b/libs/labelFile.py
@@ -10,13 +10,12 @@ from base64 import b64encode, b64decode
 from libs.pascal_voc_io import PascalVocWriter
 from libs.yolo_io import YOLOWriter
 from libs.pascal_voc_io import XML_EXT
+from file_read import read
 import os.path
 import sys
 
-
 class LabelFileError(Exception):
     pass
-
 
 class LabelFile(object):
     # It might be changed as window creates. By default, using XML ext
@@ -35,10 +34,13 @@ class LabelFile(object):
         imgFolderName = os.path.split(imgFolderPath)[-1]
         imgFileName = os.path.basename(imagePath)
         #imgFileNameWithoutExt = os.path.splitext(imgFileName)[0]
+
         # Read from file path because self.imageData might be empty if saving to
         # Pascal format
-        image = QImage()
-        image.load(imagePath)
+        if imageData is None:
+            imageData = read(imagePath)
+        image = QImage(imagePath) if imageData is None else QImage.fromData(imageData)
+
         imageShape = [image.height(), image.width(),
                       1 if image.isGrayscale() else 3]
         writer = PascalVocWriter(imgFolderName, imgFileName,


### PR DESCRIPTION
Hi,
This is a fix for https://github.com/tzutalin/labelImg/issues/160

Scraping images from Google Image Search I noticed that around 2% of files have wrong filename extension, for example .png but internally it's JPEG. 
In that case output annotation/size/ width and height are zeros.

The problem is that these two pieces of code for QImage are not equivalent:
1) Internally QImageIO discovers the format based on the file extension. This one is being used in libs/labelFile.py
```
image = QImage()
image.load('tmp/heineken_000392.png')

```
2) Internally QImageIO auto-discovers the format based on first content bytes.
```
imageData = read('tmp/heineken_000392.png')
QImage.fromData(imageData)

```

