### PR TITLE
Fix file save issue - #252, #293

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -1275,7 +1275,8 @@ class MainWindow(QMainWindow, WindowMixin):
         dlg.selectFile(filenameWithoutExtension)
         dlg.setOption(QFileDialog.DontUseNativeDialog, False)
         if dlg.exec_():
-            return dlg.selectedFiles()[0]
+            fullFilePath = dlg.selectedFiles()[0]
+            return os.path.splitext(fullFilePath)[0] # Return file path without the extension.
         return ''
 
     def _saveFile(self, annotationFilePath):


### PR DESCRIPTION
This PR fixes this issue: https://github.com/tzutalin/labelImg/issues/252, which is related to this one: https://github.com/tzutalin/labelImg/issues/293

The dilemma stems from the fact that saveFileDialog returns the full file path (C:/.../image.xml), and then in saveLabel (Lines 771, 776) the extension is added once again (C:/.../image.xml.xml).

Another solution is to just modify lines 771 and 776 to the following:
`annotationFilePath = os.path.splitext(annotationFilePath)[0] + XML_EXT`
`annotationFilePath = os.path.splitext(annotationFilePath)[0] + TXT_EXT`

LMK which you prefer.

Thanks,

-Vlad