### PR TITLE
Add item single click slot in labelDialog.py

### DIFF
--- a/libs/labelDialog.py
+++ b/libs/labelDialog.py
@@ -40,7 +40,8 @@ class LabelDialog(QDialog):
             self.listWidget = QListWidget(self)
             for item in listItem:
                 self.listWidget.addItem(item)
-            self.listWidget.itemDoubleClicked.connect(self.listItemClick)
+            self.listWidget.itemClicked.connect(self.listItemClick)
+            self.listWidget.itemDoubleClicked.connect(self.listItemDoubleClick)
             layout.addWidget(self.listWidget)
 
         self.setLayout(layout)
@@ -76,4 +77,7 @@ class LabelDialog(QDialog):
             # PyQt5: AttributeError: 'str' object has no attribute 'trimmed'
             text = tQListWidgetItem.text().strip()
         self.edit.setText(text)
+        
+    def listItemDoubleClick(self, tQLisstWidgetItem):
+        self.listItemClick(tQlistWidgetItem)
         self.validate()

--- a/libs/labelDialog.py
+++ b/libs/labelDialog.py
@@ -78,6 +78,6 @@ class LabelDialog(QDialog):
             text = tQListWidgetItem.text().strip()
         self.edit.setText(text)
         
-    def listItemDoubleClick(self, tQLisstWidgetItem):
-        self.listItemClick(tQlistWidgetItem)
+    def listItemDoubleClick(self, tQListWidgetItem):
+        self.listItemClick(tQListWidgetItem)
         self.validate()


### PR DESCRIPTION
In the original code, double clicking a list item will set the text property and automatically validate afterwards, with the label dialog window disappearing.

In this revised version, double click behavior is unchanged, while single click is added. When single clicking a list item, it will only set text in the QLineEdit. Users can change the text by clicking other items before validating themselves by clicking yes.

I think this minor modification can make this fabulous tool more user-friendly. :)

![image](https://user-images.githubusercontent.com/12013376/41274463-0aee8d8a-6e50-11e8-8695-1359a55d7837.png)
