### PR TITLE
Added offset to label's y-pos to prevent overflow of the label

### DIFF
--- a/libs/shape.py
+++ b/libs/shape.py
@@ -18,6 +18,7 @@ DEFAULT_SELECT_LINE_COLOR = QColor(255, 255, 255)
 DEFAULT_SELECT_FILL_COLOR = QColor(0, 128, 255, 155)
 DEFAULT_VERTEX_FILL_COLOR = QColor(0, 255, 0, 255)
 DEFAULT_HVERTEX_FILL_COLOR = QColor(255, 0, 0)
+MIN_Y_LABEL = 10
 
 
 class Shape(object):
@@ -124,6 +125,8 @@ class Shape(object):
                     painter.setFont(font)
                     if(self.label == None):
                         self.label = ""
+                    if(min_y < MIN_Y_LABEL):
+                        min_y += MIN_Y_LABEL
                     painter.drawText(min_x, min_y, self.label)
 
             if self.fill:


### PR DESCRIPTION
In the original code, if the bounding box is at the top position and the paint label option is enabled, the labels pained overflows the image.
![screenshot from 2018-07-08 16-52-53](https://user-images.githubusercontent.com/3715197/42419298-9a234a98-82cf-11e8-804e-6d79486a2f32.png)

In the revised code, the labels are painted inside the box when overflow occurs otherwise they are painted as it is.
![screenshot from 2018-07-08 16-52-14](https://user-images.githubusercontent.com/3715197/42419307-a4ad9752-82cf-11e8-9d1c-924dd7a0cd4e.png)

I think this change increases the label's visibility and make this tool more user-friendly.