### PR TITLE
fix bug if image files have multiple filename extensions

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -1294,7 +1294,7 @@ class MainWindow(QMainWindow, WindowMixin):
         dlg.setOption(QFileDialog.DontUseNativeDialog, False)
         if dlg.exec_():
             fullFilePath = ustr(dlg.selectedFiles()[0])
-            return os.path.splitext(fullFilePath)[0] # Return file path without the extension.
+            return fullFilePath+".xml"
         return ''
 
     def _saveFile(self, annotationFilePath):


### PR DESCRIPTION
The saveFileDialog function has a small bug. I the save dialog box, if you just click "save", and if your image name have multiple extensions, like this: foo.001.jpg,  foo.002.jpg, foo.003.jpg, all your xml will be saved as foo.xml, which is not what you want. Because you need: foo.001.xml, foo.002.xml, foo.003.xml. The problem is caused by: 
``
return os.path.splitext(fullFilePath)[0]
``
So I just return:
``
 return fullFilePath+".xml"
``