### PR TITLE
labelImg.py/loadLabels: correct shapes that are out of image bounds.

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -758,6 +758,15 @@ class MainWindow(QMainWindow, WindowMixin):
         for label, points, line_color, fill_color, difficult in shapes:
             shape = Shape(label=label)
             for x, y in points:
+
+                # Ensure the labels are within the bounds of the image. If not, fix them.
+                if x < 0 or x > self.canvas.pixmap.width() or y < 0 or y > self.canvas.pixmap.height():
+                    x = max(x, 0)
+                    y = max(y, 0)
+                    x = min(x, self.canvas.pixmap.width())
+                    y = min(y, self.canvas.pixmap.height())
+                    self.setDirty()
+
                 shape.addPoint(QPointF(x, y))
             shape.difficult = difficult
             shape.close()


### PR DESCRIPTION
Hi.

labelImg will crash when resizing a vertex of a bounding box that is outside the image boundaries:
```
Traceback (most recent call last):
  File "/Users/lgo/dev/labelImg/libs/canvas.py", line 164, in mouseMoveEvent
    self.boundedMoveVertex(pos)
  File "/Users/lgo/dev/labelImg/libs/canvas.py", line 333, in boundedMoveVertex
    pos = self.intersectionPoint(point, pos)
  File "/Users/lgo/dev/labelImg/libs/canvas.py", line 522, in intersectionPoint
    d, i, (x, y) = min(self.intersectingEdges((x1, y1), (x2, y2), points))
ValueError: min() arg is an empty sequence
```

The root cause is an invalid VOC annotation file. In this example xmax is greater than the width of the image:

```
	<size>
		<width>162</width>
		<height>130</height>
		<depth>3</depth>
	</size>
	<object>
		<name>Test</name>
		<pose>Unspecified</pose>
		<truncated>0</truncated>
		<difficult>0</difficult>
		<bndbox>
			<xmin>23</xmin>
			<ymin>29</ymin>
			<xmax>163</xmax>
			<ymax>121</ymax>
		</bndbox>
	</object>
```

Attached patch will solve this problem: when loading the labels, it will check if all 4 vertices are within the boundaries. If not, it will correct them, and mark the file as dirty.
