### PR TITLE
Avoid crash on "Edit Label" when there's no bounding boxes left.

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -675,6 +675,8 @@ class MainWindow(QMainWindow, WindowMixin):
         if not self.canvas.editing():
             return
         item = self.currentItem()
+        if not item:
+            return
         text = self.labelDialog.popUp(item.text())
         if text is not None:
             item.setText(text)


### PR DESCRIPTION
The scenario is:
1. Open an image
2. Delete all bounding boxes
3. Select "Edit Label".

* labelImg.py
  (editLabel): Avoid crash when there's no currently selected item.