### PR TITLE
Update README.rst to fix bug in instruction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,7 +118,7 @@ Open cmd and go to the `labelImg <#labelimg>`__ directory
 .. code:: shell
 
     pyrcc4 -o line/resources.py resources.qrc
-    For pyqt5, pyrcc5 -o libs/resources.py resources qrc
+    For pyqt5, pyrcc5 -o libs/resources.py resources.qrc
     
     python labelImg.py
     python labelImg.py [IMAGE_PATH] [PRE-DEFINED CLASS FILE]


### PR DESCRIPTION
Fix bug in pyqt5 compilation for windows
Changed "For pyqt5, pyrcc5 -o libs/resources.py resources qrc" to "For pyqt5, pyrcc5 -o libs/resources.py resources.qrc"