### PR TITLE
strip string of detection values

### DIFF
--- a/libs/yolo_io.py
+++ b/libs/yolo_io.py
@@ -139,7 +139,7 @@ class YoloReader:
     def parseYoloFormat(self):
         bndBoxFile = open(self.filepath, 'r')
         for bndBox in bndBoxFile:
-            classIndex, xcen, ycen, w, h = bndBox.split(' ')
+            classIndex, xcen, ycen, w, h = bndBox.strip().split(' ')
             label, xmin, ymin, xmax, ymax = self.yoloLine2Shape(classIndex, xcen, ycen, w, h)
 
             # Caveat: difficult flag is discarded when saved as yolo format.


### PR DESCRIPTION
When loading annotations from a file a crash occurs when there is white space at the end of a line. String.strip() removes the whitespace and fixes the bug.