### PR TITLE
Added hint on install method on Linux

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,6 +138,8 @@ Open the Anaconda Prompt and go to the `labelImg <#labelimg>`__ directory
 
 Get from PyPI but only python3.0 or above
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This is the simplest (one-command) install method on modern Linux distributions such as Ubuntu and Fedora.
+
 .. code:: shell
 
     pip3 install labelImg


### PR DESCRIPTION
In the list of install options, in my opinion, it is not so clear which install method an end-user should choose (at least for Linux users). Python3 is now standard on basically any Linux distro, so the install from PyPI using pip3 install should work out the box in a vast majority of distros. I tested it for Fedora32.