### PR TITLE
Documentation/Corrected anaconda windows installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,6 +132,7 @@ Open the Anaconda Prompt and go to the `labelImg <#labelimg>`__ directory
 .. code:: shell
 
     conda install pyqt=5
+    conda install -c anaconda lxml
     pyrcc5 -o libs/resources.py resources.qrc
     python labelImg.py
     python labelImg.py [IMAGE_PATH] [PRE-DEFINED CLASS FILE]


### PR DESCRIPTION
The conda installation process shows import error if we run it, since it doesnt install `lxml` package. merge this pr to correct it 