### PR TITLE
Read via QImageReader

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -1521,23 +1521,10 @@ def inverted(color):
 
 def read(filename, default=None):
     try:
-        #with open(filename, 'rb') as f:
-        #    return f.read()
         reader = QImageReader(filename)
         reader.setAutoTransform(True)
-        loaded_image = reader.read()
-        if loaded_image.isNull():
-            return default
-        """
-        image_ba = QByteArray()
-        buf = QBuffer(image_ba)
-        buf.open(QIODevice.WriteOnly)
-        loaded_image.save(buf, "PNG")
-        return image_ba
-        """
-        return loaded_image
+        return reader.read()
     except:
-        raise
         return default
 
 

--- a/labelImg.py
+++ b/labelImg.py
@@ -1046,7 +1046,10 @@ class MainWindow(QMainWindow, WindowMixin):
                 self.labelFile = None
                 self.canvas.verified = False
 
-            image = QImage.fromData(self.imageData)
+            if isinstance(self.imageData, QImage):
+                image = self.imageData
+            else:
+                image = QImage.fromData(self.imageData)
             if image.isNull():
                 self.errorMessage(u'Error opening file',
                                   u"<p>Make sure <i>%s</i> is a valid image file." % unicodeFilePath)
@@ -1518,9 +1521,23 @@ def inverted(color):
 
 def read(filename, default=None):
     try:
-        with open(filename, 'rb') as f:
-            return f.read()
+        #with open(filename, 'rb') as f:
+        #    return f.read()
+        reader = QImageReader(filename)
+        reader.setAutoTransform(True)
+        loaded_image = reader.read()
+        if loaded_image.isNull():
+            return default
+        """
+        image_ba = QByteArray()
+        buf = QBuffer(image_ba)
+        buf.open(QIODevice.WriteOnly)
+        loaded_image.save(buf, "PNG")
+        return image_ba
+        """
+        return loaded_image
     except:
+        raise
         return default
 
 

--- a/libs/labelFile.py
+++ b/libs/labelFile.py
@@ -43,8 +43,11 @@ class LabelFile(object):
         #imgFileNameWithoutExt = os.path.splitext(imgFileName)[0]
         # Read from file path because self.imageData might be empty if saving to
         # Pascal format
-        image = QImage()
-        image.load(imagePath)
+        if isinstance(imageData, QImage):
+            image = imageData
+        else:
+            image = QImage()
+            image.load(imagePath)
         imageShape = [image.height(), image.width(),
                       1 if image.isGrayscale() else 3]
         writer = PascalVocWriter(imgFolderName, imgFileName,
@@ -70,8 +73,11 @@ class LabelFile(object):
         #imgFileNameWithoutExt = os.path.splitext(imgFileName)[0]
         # Read from file path because self.imageData might be empty if saving to
         # Pascal format
-        image = QImage()
-        image.load(imagePath)
+        if isinstance(imageData, QImage):
+            image = imageData
+        else:
+            image = QImage()
+            image.load(imagePath)
         imageShape = [image.height(), image.width(),
                       1 if image.isGrayscale() else 3]
         writer = YOLOWriter(imgFolderName, imgFileName,


### PR DESCRIPTION
This branch includes commits resolving image rotation problem by EXIF Orientation tag, addressed in #198 . 
Modified `read()` function in `labelImg.py` so now it reads image through `QImageReader` to use auto-transform feature of it. This feature allows the reader reads image properly oriented by EXIF Orientation tag.
Also modified saver functions in `libs/labelFile.py` because saved label contains before-oriented height and width information. Now it uses `imageData` parameter, which is `QImage`, read from `QImageReader`, so it has properly oriented height and width information.

#198 #633 