### PR TITLE
sort bndbox orders

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -766,17 +766,18 @@ class MainWindow(QMainWindow, WindowMixin):
         self.actions.shapeFillColor.setEnabled(selected)
 
     def addLabel(self, shape):
-        shape.paintLabel = self.displayLabelOption.isChecked()
-        item = HashableQListWidgetItem(shape.label)
-        item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
-        item.setCheckState(Qt.Checked)
-        item.setBackground(generateColorByText(shape.label))
-        self.itemsToShapes[item] = shape
-        self.shapesToItems[shape] = item
-        self.labelList.addItem(item)
-        for action in self.actions.onShapesPresent:
-            action.setEnabled(True)
-        self.updateComboBox()
+        if shape is not None:
+            shape.paintLabel = self.displayLabelOption.isChecked()
+            item = HashableQListWidgetItem(shape.label)
+            item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+            item.setCheckState(Qt.Checked)
+            item.setBackground(generateColorByText(shape.label))
+            self.itemsToShapes[item] = shape
+            self.shapesToItems[shape] = item
+            self.labelList.addItem(item)
+            for action in self.actions.onShapesPresent:
+                action.setEnabled(True)
+            self.updateComboBox()
 
     def remLabel(self, shape):
         if shape is None:


### PR DESCRIPTION
Hi, I usually use labelImg to annotate small objects.  Sometimes I will change the  annotations generated from the model I trained, but the bndbox orders are in a mess. So  I add some codes to make sure the objects are in a left-to-right and top-to-bottom order.

It works for me.