### PR TITLE
Adaptively adjust label size

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -1141,6 +1141,7 @@ class MainWindow(QMainWindow, WindowMixin):
     def paintCanvas(self):
         assert not self.image.isNull(), "cannot paint null image"
         self.canvas.scale = 0.01 * self.zoomWidget.value()
+        self.canvas.labelFontSize = int(0.02 * self.image.width())
         self.canvas.adjustSize()
         self.canvas.update()
 

--- a/labelImg.py
+++ b/labelImg.py
@@ -1141,7 +1141,7 @@ class MainWindow(QMainWindow, WindowMixin):
     def paintCanvas(self):
         assert not self.image.isNull(), "cannot paint null image"
         self.canvas.scale = 0.01 * self.zoomWidget.value()
-        self.canvas.labelFontSize = int(0.02 * self.image.width())
+        self.canvas.labelFontSize = int(0.02 * max(self.image.width(), self.image.height()))
         self.canvas.adjustSize()
         self.canvas.update()
 

--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -47,6 +47,7 @@ class Canvas(QWidget):
         self.prevPoint = QPointF()
         self.offsets = QPointF(), QPointF()
         self.scale = 1.0
+        self.labelFontSize = 8
         self.pixmap = QPixmap()
         self.visible = {}
         self._hideBackround = False
@@ -478,6 +479,7 @@ class Canvas(QWidget):
 
         p.drawPixmap(0, 0, self.pixmap)
         Shape.scale = self.scale
+        Shape.labelFontSize = self.labelFontSize
         for shape in self.shapes:
             if (shape.selected or not self._hideBackround) and self.isVisible(shape):
                 shape.fill = shape.selected or shape == self.hShape

--- a/libs/shape.py
+++ b/libs/shape.py
@@ -18,7 +18,6 @@ DEFAULT_SELECT_LINE_COLOR = QColor(255, 255, 255)
 DEFAULT_SELECT_FILL_COLOR = QColor(0, 128, 255, 155)
 DEFAULT_VERTEX_FILL_COLOR = QColor(0, 255, 0, 255)
 DEFAULT_HVERTEX_FILL_COLOR = QColor(255, 0, 0)
-MIN_Y_LABEL = 10
 
 
 class Shape(object):
@@ -116,6 +115,7 @@ class Shape(object):
             if self.paintLabel:
                 min_x = sys.maxsize
                 min_y = sys.maxsize
+                min_y_label = int(1.25 * self.labelFontSize)
                 for point in self.points:
                     min_x = min(min_x, point.x())
                     min_y = min(min_y, point.y())
@@ -126,8 +126,8 @@ class Shape(object):
                     painter.setFont(font)
                     if(self.label == None):
                         self.label = ""
-                    if(min_y < MIN_Y_LABEL):
-                        min_y += MIN_Y_LABEL
+                    if(min_y < min_y_label):
+                        min_y += min_y_label
                     painter.drawText(min_x, min_y, self.label)
 
             if self.fill:

--- a/libs/shape.py
+++ b/libs/shape.py
@@ -37,6 +37,7 @@ class Shape(object):
     point_type = P_ROUND
     point_size = 8
     scale = 1.0
+    labelFontSize = 8
 
     def __init__(self, label=None, line_color=None, difficult=False, paintLabel=False):
         self.label = label
@@ -120,7 +121,7 @@ class Shape(object):
                     min_y = min(min_y, point.y())
                 if min_x != sys.maxsize and min_y != sys.maxsize:
                     font = QFont()
-                    font.setPointSize(8)
+                    font.setPointSize(self.labelFontSize)
                     font.setBold(True)
                     painter.setFont(font)
                     if(self.label == None):


### PR DESCRIPTION
The painted label name on the bounding box has a fixed font size. However, current devices can easily take images with high resolution (>1000 pixels per edge). The fixed font size of 8 is hardly visible in such images. Therefore, I propose to adaptively adjust the font size based on the image resolution.