### PR TITLE
Add 16 bit image support

### DIFF
--- a/requirements/requirements-linux-python3.txt
+++ b/requirements/requirements-linux-python3.txt
@@ -1,2 +1,4 @@
 pyqt5==5.10.1
 lxml==4.6.2
+opencv-python>=4.2.0.0
+numpy>=1.11.3


### PR DESCRIPTION
I wasn't sure how you feel about requiring more external libraries, but since there was a request about this feature (https://github.com/tzutalin/labelImg/issues/683), I didn't see any other way besides loading the images with opencv.

This may even support more image formats than Qt does out of the box, and I took care to make sure that image formats not supported by opencv (like svg) can be labeled using Qt's image loading mechanism.