### PR TITLE
Change encoding. Fix for #676

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,11 @@ about = {}
 with open(os.path.join(here, 'libs', '__init__.py')) as f:
     exec(f.read(), about)
 
-with open('README.rst') as readme_file:
-    readme = readme_file.read()
+with open("README.rst", "rb") as readme_file:
+    readme = readme_file.read().decode("UTF-8")
 
-with open('HISTORY.rst') as history_file:
-    history = history_file.read()
-
+with open("HISTORY.rst", "rb") as history_file:
+    history = history_file.read().decode("UTF-8")
 
 # OS specific settings
 SET_REQUIRES = []


### PR DESCRIPTION
First read the file in binary mode. Then, convert to utf-8. Fix for https://github.com/tzutalin/labelImg/issues/676