### PR TITLE
Fix rounding issue that caused 1px box shift for YOLO format

### DIFF
--- a/libs/yolo_io.py
+++ b/libs/yolo_io.py
@@ -129,10 +129,10 @@ class YoloReader:
         y_min = max(float(y_center) - float(h) / 2, 0)
         y_max = min(float(y_center) + float(h) / 2, 1)
 
-        x_min = int(self.img_size[1] * x_min)
-        x_max = int(self.img_size[1] * x_max)
-        y_min = int(self.img_size[0] * y_min)
-        y_max = int(self.img_size[0] * y_max)
+        x_min = round(self.img_size[1] * x_min)
+        x_max = round(self.img_size[1] * x_max)
+        y_min = round(self.img_size[0] * y_min)
+        y_max = round(self.img_size[0] * y_max)
 
         return label, x_min, y_min, x_max, y_max
 


### PR DESCRIPTION
Fixes #729 
Rounding issue caused box to shift by 1px from where it was placed.

```
Converting from box to YOLO...
Img W x H: 416 x 295
Shape x_min: 6, y_min: 11, x_max: 96, y_max: 98
YOLO x_center: 0.12259615384615384, y_center: 0.1847457627118644, w: 0.21634615384615385 h: 0.29491525423728815.
```

Will be saved as `0 0.122596 0.184745 0.216346 0.294915` by this line:
https://github.com/tzutalin/labelImg/blob/3425fefd8de8ce0a00cd589f5572190f80be52b0/libs/yolo_io.py#L72

After reading the file and converting back to box:
```
Converting from YOLO to box...
Img W x H: 416 x 295
YOLO x_center: 0.122596, y_center: 0.184746, w: 0.216346 h: 0.294915
Shape x_min: 5, y_min: 11, x_max: 95, y_max: 98.
```
Because of truncation to 6 digits after the decimal point some accuracy loss happens.
`x_min = (x_center - w / 2) * img_w = 5.999967999999996`

The result get truncated by the following code:
https://github.com/tzutalin/labelImg/blob/3425fefd8de8ce0a00cd589f5572190f80be52b0/libs/yolo_io.py#L132

To fix the issue result should be rounded to the nearest integer.
https://github.com/Ledorub/labelImg/blob/76d4638aa87fc546925e4ebee037fefe744729f8/libs/yolo_io.py#L132-L135