### PR TITLE
Fix incorrect path handling

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -1583,14 +1583,19 @@ def get_main_app(argv=[]):
     # Tzutalin 201705+: Accept extra agruments to change predefined class file
     argparser = argparse.ArgumentParser()
     argparser.add_argument("image_dir", nargs="?")
-    argparser.add_argument("predefined_classes_file",
+    argparser.add_argument("class_file",
                            default=os.path.join(os.path.dirname(__file__), "data", "predefined_classes.txt"),
                            nargs="?")
     argparser.add_argument("save_dir", nargs="?")
     args = argparser.parse_args(argv[1:])
-    # Usage : labelImg.py image predefClassFile saveDir
+
+    args.image_dir = args.image_dir and os.path.normpath(args.image_dir)
+    args.class_file = args.class_file and os.path.normpath(args.class_file)
+    args.save_dir = args.save_dir and os.path.normpath(args.save_dir)
+
+    # Usage : labelImg.py image classFile saveDir
     win = MainWindow(args.image_dir,
-                     args.predefined_classes_file,
+                     args.class_file,
                      args.save_dir)
     win.show()
     return app, win

--- a/labelImg.py
+++ b/labelImg.py
@@ -1109,10 +1109,9 @@ class MainWindow(QMainWindow, WindowMixin):
     def show_bounding_box_from_annotation_file(self, file_path):
         if self.default_save_dir is not None:
             basename = os.path.basename(os.path.splitext(file_path)[0])
-            file_dir = file_path.split(basename)[0].split(os.path.sep)[-2:-1][0]
             xml_path = os.path.join(self.default_save_dir, basename + XML_EXT)
             txt_path = os.path.join(self.default_save_dir, basename + TXT_EXT)
-            json_path = os.path.join(self.default_save_dir, file_dir + JSON_EXT)
+            json_path = os.path.join(self.default_save_dir, basename + JSON_EXT)
 
             """Annotation file priority:
             PascalXML > YOLO

--- a/libs/create_ml_io.py
+++ b/libs/create_ml_io.py
@@ -97,7 +97,7 @@ class CreateMLReader:
         self.json_path = json_path
         self.shapes = []
         self.verified = False
-        self.filename = file_path.split("/")[-1:][0]
+        self.filename = os.path.basename(file_path)
         try:
             self.parse_json()
         except ValueError:

--- a/libs/labelFile.py
+++ b/libs/labelFile.py
@@ -39,18 +39,15 @@ class LabelFile(object):
         self.verified = False
 
     def save_create_ml_format(self, filename, shapes, image_path, image_data, class_list, line_color=None, fill_color=None, database_src=None):
-        img_folder_path = os.path.dirname(image_path)
-        img_folder_name = os.path.split(img_folder_path)[-1]
+        img_folder_name = os.path.basename(os.path.dirname(image_path))
         img_file_name = os.path.basename(image_path)
-        output_file_path = "/".join(filename.split("/")[:-1])
-        output_file = output_file_path + "/" + img_folder_name + JSON_EXT
 
         image = QImage()
         image.load(image_path)
         image_shape = [image.height(), image.width(),
                        1 if image.isGrayscale() else 3]
         writer = CreateMLWriter(img_folder_name, img_file_name,
-                                image_shape, shapes, output_file, local_img_path=image_path)
+                                image_shape, shapes, filename, local_img_path=image_path)
         writer.verified = self.verified
         writer.write()
 


### PR DESCRIPTION
https://github.com/tzutalin/labelImg/pull/731/commits/755bafdb3845a12c7d10f7b69c34e37c5eab6010 fixes #724.
`labelFile.LabelFile.save_create_ml_format` handles output file path incorrectly.
It tries to construct path to label file which is already passed to it as `filename` parameter.

`labelImg.MainWindow.save_file` calls `os.path.join` which uses `os.sep` as separator. '\\\\' for NT.
https://github.com/tzutalin/labelImg/blob/0573a39ec3b1a3accbcf7e66c3ebd3155120c9cd/labelImg.py#L1372
Path to save dir, that can also be provided as command argument (e.g. `C:/Users/admin/labels`), is joined with mantissa of image filename (e.g. `image`) resulting in path with different separators (`C:/Users/admin/labels\\image`).

`labelFile.LabelFile.save_create_ml_format` tries to split path by '/' separator and join everything but last item with '/' as separator (`C:/Users/admin`).
https://github.com/tzutalin/labelImg/blob/0573a39ec3b1a3accbcf7e66c3ebd3155120c9cd/libs/labelFile.py#L45
`str.split` with '/' as delimiter is not OS-independent.

Name of the folder containing images (e.g. `images`) and appropriate extension are then appended (`C:/Users/admin/images.json`).
https://github.com/tzutalin/labelImg/blob/0573a39ec3b1a3accbcf7e66c3ebd3155120c9cd/libs/labelFile.py#L46
The aforementioned bug is the cause of all labels being saved with the same name to the wrong directory.