### PR TITLE
Fix deletion of image caused selection of the first image

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -1428,12 +1428,15 @@ class MainWindow(QMainWindow, WindowMixin):
     def delete_image(self):
         delete_path = self.file_path
         if delete_path is not None:
-            self.open_next_image()
-            self.cur_img_idx -= 1
+            del self.m_img_list[self.cur_img_idx]
+            self.file_list_widget.takeItem(self.cur_img_idx)
+
+            self.cur_img_idx -= 1  # self.open_next_img will increment idx.
             self.img_count -= 1
+            self.open_next_image()
+
             if os.path.exists(delete_path):
                 os.remove(delete_path)
-            self.import_dir_images(self.last_open_dir)
 
     def reset_all(self):
         self.settings.reset()


### PR DESCRIPTION
`self.import_dir_images` sets `self.file_path` to `None`
https://github.com/tzutalin/labelImg/blob/6b5c3c634b4ec2976d87414e4ae1de9cc1ed358c/labelImg.py#L1282
then rescans the directory
https://github.com/tzutalin/labelImg/blob/6b5c3c634b4ec2976d87414e4ae1de9cc1ed358c/labelImg.py#L1283-L1284
and reloads all items of the widget
https://github.com/tzutalin/labelImg/blob/6b5c3c634b4ec2976d87414e4ae1de9cc1ed358c/labelImg.py#L1287-L1289
afterwards calls `self.open_next_image`
https://github.com/tzutalin/labelImg/blob/6b5c3c634b4ec2976d87414e4ae1de9cc1ed358c/labelImg.py#L1286
The following condition is met and `self.cur_img_idx` is reset.
https://github.com/tzutalin/labelImg/blob/6b5c3c634b4ec2976d87414e4ae1de9cc1ed358c/labelImg.py#L1351-L1353