### PR TITLE
adds a utility function to hide a QT5/QT4 discrepancy

### DIFF
--- a/libs/labelDialog.py
+++ b/libs/labelDialog.py
@@ -6,7 +6,7 @@ except ImportError:
     from PyQt4.QtGui import *
     from PyQt4.QtCore import *
 
-from libs.utils import new_icon, label_validator
+from libs.utils import new_icon, label_validator, trimmed
 
 BB = QDialogButtonBox
 
@@ -47,22 +47,18 @@ class LabelDialog(QDialog):
         self.setLayout(layout)
 
     def validate(self):
-        try:
-            if self.edit.text().trimmed():
-                self.accept()
-        except AttributeError:
-            # PyQt5: AttributeError: 'str' object has no attribute 'trimmed'
-            if self.edit.text().strip():
-                self.accept()
+        if trimmed(self.edit.text()):
+            self.accept()
 
     def post_process(self):
-        try:
-            self.edit.setText(self.edit.text().trimmed())
-        except AttributeError:
-            # PyQt5: AttributeError: 'str' object has no attribute 'trimmed'
-            self.edit.setText(self.edit.text())
+        self.edit.setText(trimmed(self.edit.text()))
 
     def pop_up(self, text='', move=True):
+        """
+        Shows the dialog, setting the current text to `text`, and blocks the caller until the user has made a choice.
+        If the user entered a label, that label is returned, otherwise (i.e. if the user cancelled the action)
+        `None` is returned.
+        """
         self.edit.setText(text)
         self.edit.setSelection(0, len(text))
         self.edit.setFocus(Qt.PopupFocusReason)
@@ -77,14 +73,10 @@ class LabelDialog(QDialog):
             if cursor_pos.y() > max_global.y():
                 cursor_pos.setY(max_global.y())
             self.move(cursor_pos)
-        return self.edit.text() if self.exec_() else None
+        return trimmed(self.edit.text()) if self.exec_() else None
 
     def list_item_click(self, t_qlist_widget_item):
-        try:
-            text = t_qlist_widget_item.text().trimmed()
-        except AttributeError:
-            # PyQt5: AttributeError: 'str' object has no attribute 'trimmed'
-            text = t_qlist_widget_item.text().strip()
+        text = trimmed(t_qlist_widget_item.text())
         self.edit.setText(text)
 
     def list_item_double_click(self, t_qlist_widget_item):

--- a/libs/utils.py
+++ b/libs/utils.py
@@ -8,9 +8,11 @@ try:
     from PyQt5.QtGui import *
     from PyQt5.QtCore import *
     from PyQt5.QtWidgets import *
+    QT5 = True
 except ImportError:
     from PyQt4.QtGui import *
     from PyQt4.QtCore import *
+    QT5 = False
 
 
 def new_icon(icon):
@@ -85,12 +87,15 @@ def generate_color_by_text(text):
     b = int((hash_code / 16581375) % 255)
     return QColor(r, g, b, 100)
 
+
 def have_qstring():
     """p3/qt5 get rid of QString wrapper as py3 has native unicode str type"""
     return not (sys.version_info.major >= 3 or QT_VERSION_STR.startswith('5.'))
 
+
 def util_qt_strlistclass():
     return QStringList if have_qstring() else list
+
 
 def natural_sort(list, key=lambda s:s):
     """
@@ -101,3 +106,12 @@ def natural_sort(list, key=lambda s:s):
         return lambda s: [convert(c) for c in re.split('([0-9]+)', key(s))]
     sort_key = get_alphanum_key_func(key)
     list.sort(key=sort_key)
+
+
+# QT4 has a trimmed method, in QT5 this is called strip
+if QT5:
+    def trimmed(text):
+        return text.strip()
+else:
+    def trimmed(text):
+        return text.trimmed()


### PR DESCRIPTION
The old code needed to trim the returned text at multiple places. This method changed names between QT4 and QT5, so I've consolidated this into a utility function. The implementation of this function is chosen at import time.