### PR TITLE
replace pyqt5 to pyside6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
 # ex: set ts=8 noet:
 
-all: qt5 test
+all: pyside6 test
 
 test: testpy3
 
 testpy2:
 	python -m unittest discover tests
+
+pyside6:
+	pyside6-rcc -o libs/resources.py resources.qrc
 
 testpy3:
 	python3 -m unittest discover tests

--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -1,13 +1,8 @@
-
-try:
-    from PyQt5.QtGui import *
-    from PyQt5.QtCore import *
-    from PyQt5.QtWidgets import *
-except ImportError:
-    from PyQt4.QtGui import *
-    from PyQt4.QtCore import *
-
-# from PyQt4.QtOpenGL import *
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from PySide6.QtCore import QPointF, QPoint, Qt, Signal
+from PySide6.QtGui import QColor, QPixmap, QPainter, QCursor, QBrush
+from PySide6.QtWidgets import QMenu, QApplication, QWidget
 
 from libs.shape import Shape
 from libs.utils import distance
@@ -22,12 +17,12 @@ CURSOR_GRAB = Qt.OpenHandCursor
 
 
 class Canvas(QWidget):
-    zoomRequest = pyqtSignal(int)
-    scrollRequest = pyqtSignal(int, int)
-    newShape = pyqtSignal()
-    selectionChanged = pyqtSignal(bool)
-    shapeMoved = pyqtSignal()
-    drawingPolygon = pyqtSignal(bool)
+    zoomRequest = Signal(int)
+    scrollRequest = Signal(int, int)
+    newShape = Signal()
+    selectionChanged = Signal(bool)
+    shapeMoved = Signal()
+    drawingPolygon = Signal(bool)
 
     CREATE, EDIT = list(range(2))
 
@@ -495,7 +490,7 @@ class Canvas(QWidget):
         p = self._painter
         p.begin(self)
         p.setRenderHint(QPainter.Antialiasing)
-        p.setRenderHint(QPainter.HighQualityAntialiasing)
+        #p.setRenderHint(QPainter.HighQualityAntialiasing)#This value is obsolete and will be ignored, use the Antialiasing render hint instead.
         p.setRenderHint(QPainter.SmoothPixmapTransform)
 
         p.scale(self.scale, self.scale)
@@ -544,6 +539,7 @@ class Canvas(QWidget):
 
     def transform_pos(self, point):
         """Convert from widget-logical coordinates to painter-logical coordinates."""
+        point = QPointF(point.x() ,point.y() )
         return point / self.scale - self.offset_to_center()
 
     def offset_to_center(self):

--- a/libs/colorDialog.py
+++ b/libs/colorDialog.py
@@ -1,10 +1,5 @@
-try:
-    from PyQt5.QtGui import *
-    from PyQt5.QtCore import *
-    from PyQt5.QtWidgets import QColorDialog, QDialogButtonBox
-except ImportError:
-    from PyQt4.QtGui import *
-    from PyQt4.QtCore import *
+from PySide6.QtWidgets import QColorDialog, QDialogButtonBox
+
 
 BB = QDialogButtonBox
 

--- a/libs/combobox.py
+++ b/libs/combobox.py
@@ -1,15 +1,7 @@
-import sys
-try:
-    from PyQt5.QtWidgets import QWidget, QHBoxLayout, QComboBox
-except ImportError:
-    # needed for py3+qt4
-    # Ref:
-    # http://pyqt.sourceforge.net/Docs/PyQt4/incompatible_apis.html
-    # http://stackoverflow.com/questions/21217399/pyqt4-qtcore-qvariant-object-instead-of-a-string
-    if sys.version_info.major >= 3:
-        import sip
-        sip.setapi('QVariant', 2)
-    from PyQt4.QtGui import QWidget, QHBoxLayout, QComboBox
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from PySide6.QtWidgets import QWidget, QHBoxLayout, QComboBox
+
 
 
 class ComboBox(QWidget):

--- a/libs/hashableQListWidgetItem.py
+++ b/libs/hashableQListWidgetItem.py
@@ -1,23 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import sys
-try:
-    from PyQt5.QtGui import *
-    from PyQt5.QtCore import *
-    from PyQt5.QtWidgets import *
-except ImportError:
-    # needed for py3+qt4
-    # Ref:
-    # http://pyqt.sourceforge.net/Docs/PyQt4/incompatible_apis.html
-    # http://stackoverflow.com/questions/21217399/pyqt4-qtcore-qvariant-object-instead-of-a-string
-    if sys.version_info.major >= 3:
-        import sip
-        sip.setapi('QVariant', 2)
-    from PyQt4.QtGui import *
-    from PyQt4.QtCore import *
 
-# PyQt5: TypeError: unhashable type: 'QListWidgetItem'
-
+from PySide6.QtWidgets import QListWidgetItem
 
 class HashableQListWidgetItem(QListWidgetItem):
 

--- a/libs/labelDialog.py
+++ b/libs/labelDialog.py
@@ -1,10 +1,7 @@
-try:
-    from PyQt5.QtGui import *
-    from PyQt5.QtCore import *
-    from PyQt5.QtWidgets import *
-except ImportError:
-    from PyQt4.QtGui import *
-    from PyQt4.QtCore import *
+
+from PySide6.QtCore import QStringListModel, Qt, QPoint
+from PySide6.QtGui import QCursor
+from PySide6.QtWidgets import QDialogButtonBox, QDialog, QLineEdit, QCompleter, QVBoxLayout, QListWidget
 
 from libs.utils import new_icon, label_validator, trimmed
 

--- a/libs/labelFile.py
+++ b/libs/labelFile.py
@@ -1,10 +1,7 @@
 # Copyright (c) 2016 Tzutalin
 # Create by TzuTaLin <tzu.ta.lin@gmail.com>
+from PySide6.QtGui import QImage
 
-try:
-    from PyQt5.QtGui import QImage
-except ImportError:
-    from PyQt4.QtGui import QImage
 
 from base64 import b64encode, b64decode
 from libs.pascal_voc_io import PascalVocWriter

--- a/libs/shape.py
+++ b/libs/shape.py
@@ -1,14 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-
-
-try:
-    from PyQt5.QtGui import *
-    from PyQt5.QtCore import *
-except ImportError:
-    from PyQt4.QtGui import *
-    from PyQt4.QtCore import *
-
+from PySide6.QtGui import QColor, QPen, QPainterPath, QFont
 from libs.utils import distance
 import sys
 

--- a/libs/stringBundle.py
+++ b/libs/stringBundle.py
@@ -2,22 +2,18 @@
 # -*- coding: utf-8 -*-
 """
 if items were added in files in the resources/strings folder,
-then execute "pyrcc5 resources.qrc -o resources.py" in the root directory
-and execute "pyrcc5 ../resources.qrc -o resources.py" in the libs directory
+then execute "pyside6-rcc resources.qrc -o resources.py" in the root directory
+and execute "pyside6-rcc ../resources.qrc -o resources.py" in the libs directory
 """
 import re
 import os
-import sys
 import locale
+
+
+
 from libs.ustr import ustr
 
-try:
-    from PyQt5.QtCore import *
-except ImportError:
-    if sys.version_info.major >= 3:
-        import sip
-        sip.setapi('QVariant', 2)
-    from PyQt4.QtCore import *
+from PySide6.QtCore import QIODevice, QFile, QTextStream, QStringConverter
 
 
 class StringBundle:
@@ -66,7 +62,7 @@ class StringBundle:
         if f.exists():
             if f.open(QIODevice.ReadOnly | QFile.Text):
                 text = QTextStream(f)
-                text.setCodec("UTF-8")
+                text.setEncoding(QStringConverter.Utf8)
 
             while not text.atEnd():
                 line = ustr(text.readLine())

--- a/libs/toolBar.py
+++ b/libs/toolBar.py
@@ -1,11 +1,5 @@
-try:
-    from PyQt5.QtGui import *
-    from PyQt5.QtCore import *
-    from PyQt5.QtWidgets import *
-except ImportError:
-    from PyQt4.QtGui import *
-    from PyQt4.QtCore import *
-
+from PySide6.QtCore import QSize,Qt
+from PySide6.QtWidgets import QToolBar, QWidgetAction, QToolButton
 
 class ToolBar(QToolBar):
 

--- a/libs/ustr.py
+++ b/libs/ustr.py
@@ -1,11 +1,14 @@
 import sys
+
+from lxml.builder import unicode
+
 from libs.constants import DEFAULT_ENCODING
 
-def ustr(x):
+def ustr(x): #I believe this is not necessary
     """py2/py3 unicode helper"""
 
     if sys.version_info < (3, 0, 0):
-        from PyQt4.QtCore import QString
+        from PySide6.QtCore import QString
         if type(x) == str:
             return x.decode(DEFAULT_ENCODING)
         if type(x) == QString:

--- a/libs/utils.py
+++ b/libs/utils.py
@@ -1,19 +1,12 @@
 from math import sqrt
+
+
 from libs.ustr import ustr
 import hashlib
 import re
-import sys
 
-try:
-    from PyQt5.QtGui import *
-    from PyQt5.QtCore import *
-    from PyQt5.QtWidgets import *
-    QT5 = True
-except ImportError:
-    from PyQt4.QtGui import *
-    from PyQt4.QtCore import *
-    QT5 = False
-
+from PySide6.QtGui import QIcon, QAction, QColor, QRegularExpressionValidator
+from PySide6.QtWidgets import QPushButton, QMenu
 
 def new_icon(icon):
     return QIcon(':/' + icon)
@@ -61,8 +54,9 @@ def add_actions(widget, actions):
 
 
 def label_validator():
-    return QRegExpValidator(QRegExp(r'^[^ \t].+'), None)
-
+     #from PySide6.QtCore import QReg
+     #return QValidator(QRegularExpression(r'^[^ \t].+'), None)
+     return QRegularExpressionValidator(r'^[^ \t].+',None)
 
 class Struct(object):
 
@@ -88,14 +82,14 @@ def generate_color_by_text(text):
     return QColor(r, g, b, 100)
 
 
-def have_qstring():
-    """p3/qt5 get rid of QString wrapper as py3 has native unicode str type"""
-    return not (sys.version_info.major >= 3 or QT_VERSION_STR.startswith('5.'))
+ #def have_qstring():
+ #    """p3/qt5 get rid of QString wrapper as py3 has native unicode str type"""
+ #    return not (sys.version_info.major >= 3 or QT_VERSION_STR.startswith('5.'))
 
 
-def util_qt_strlistclass():
-    return QStringList if have_qstring() else list
-
+# def util_qt_strlistclass():
+#     return QStringList if have_qstring() else list
+#
 
 def natural_sort(list, key=lambda s:s):
     """
@@ -107,11 +101,12 @@ def natural_sort(list, key=lambda s:s):
     sort_key = get_alphanum_key_func(key)
     list.sort(key=sort_key)
 
-
+def trimmed(text):
+    return text.strip()
 # QT4 has a trimmed method, in QT5 this is called strip
-if QT5:
-    def trimmed(text):
-        return text.strip()
-else:
-    def trimmed(text):
-        return text.trimmed()
+# if QT5:
+#     def trimmed(text):
+#         return text.strip()
+# else:
+#     def trimmed(text):
+#         return text.trimmed()

--- a/libs/zoomWidget.py
+++ b/libs/zoomWidget.py
@@ -1,10 +1,7 @@
-try:
-    from PyQt5.QtGui import *
-    from PyQt5.QtCore import *
-    from PyQt5.QtWidgets import *
-except ImportError:
-    from PyQt4.QtGui import *
-    from PyQt4.QtCore import *
+
+from PySide6.QtCore import QSize,Qt
+from PySide6.QtGui import QFontMetrics
+from PySide6.QtWidgets import QSpinBox, QAbstractSpinBox
 
 
 class ZoomWidget(QSpinBox):
@@ -22,5 +19,6 @@ class ZoomWidget(QSpinBox):
     def minimumSizeHint(self):
         height = super(ZoomWidget, self).minimumSizeHint().height()
         fm = QFontMetrics(self.font())
-        width = fm.width(str(self.maximum()))
+        #width = fm.width(str(self.maximum()))
+        width = fm.maxWidth()
         return QSize(width, height)

--- a/requirements/requirements-linux-python3.txt
+++ b/requirements/requirements-linux-python3.txt
@@ -1,2 +1,5 @@
-pyqt5==5.10.1
 lxml==4.6.3
+PySide6==6.2.0
+shiboken6==6.2.0
+
+


### PR DESCRIPTION
Tested in ubuntu 20.04
python 3.9

Run

```
cd labelImg

python3 -m venv
source bin/activate
pyside6-rcc -o libs/resources.py resources.qrc
pip3 install requirements/requirements-linux-python3.txt

python3 labelImg.py
```
# critical change
1.
Note: i don't know if it works because i only have one screen.
 in labelImg.py line 452
```
        for i in range(len(QApplication.screens())):
            if QApplication.screens()[i].availableGeometry().contains(saved_position):
                position = saved_position
                break
```
2.
in ustr.py file I think it is not necessary
