### PR TITLE
removed a default mutable argument pitfall

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -1600,11 +1600,13 @@ def read(filename, default=None):
         return default
 
 
-def get_main_app(argv=[]):
+def get_main_app(argv=None):
     """
     Standard boilerplate Qt application code.
     Do everything but app.exec_() -- so that we can test the application in one thread
     """
+    if not argv:
+        argv = []
     app = QApplication(argv)
     app.setApplicationName(__appname__)
     app.setWindowIcon(new_icon("app"))


### PR DESCRIPTION
**The problem**
In Python it usually dangerous to use mutable arguments like dicts or lists as default arguments in method, as is better explained [here](https://docs.python-guide.org/writing/gotchas/)

**the solution**
This PR applies a simple refactoring to remove a case where a method was created using default a mutable argument