### PR TITLE
[fix] avoid classes.txt replaced by data second adjust

### DIFF
--- a/libs/yolo_io.py
+++ b/libs/yolo_io.py
@@ -63,7 +63,7 @@ class YOLOWriter:
         else:
             out_file = codecs.open(target_file, 'w', encoding=ENCODE_METHOD)
             classes_file = os.path.join(os.path.dirname(os.path.abspath(target_file)), "classes.txt")
-            out_class_file = open(classes_file, 'w')
+            out_class_file = open(classes_file, 'a')
 
 
         for box in self.box_list:


### PR DESCRIPTION
修复二次标注调整时, classes.txt会被替换引起的IndexError问题