### PR TITLE
fix h_vertex being kept after deleting shape, causing a crash if used

### DIFF
--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -97,10 +97,11 @@ class Canvas(QWidget):
         self.prev_point = QPointF()
         self.repaint()
 
-    def un_highlight(self):
-        if self.h_shape:
-            self.h_shape.highlight_clear()
-        self.h_vertex = self.h_shape = None
+    def un_highlight(self, shape=None):
+        if shape == None or shape == self.h_shape:
+            if self.h_shape:
+                self.h_shape.highlight_clear()
+            self.h_vertex = self.h_shape = None
 
     def selected_vertex(self):
         return self.h_vertex is not None
@@ -463,6 +464,7 @@ class Canvas(QWidget):
     def delete_selected(self):
         if self.selected_shape:
             shape = self.selected_shape
+            self.un_highlight(shape)
             self.shapes.remove(self.selected_shape)
             self.selected_shape = None
             self.update()


### PR DESCRIPTION
Steps to reproduce this particular issue:

1. draw a box
2. select the box
3. hover over one of the corners as if you want to resize the box (no click needed)
4. press DEL to delete the box
5. left click on the canvas

Note there are two more destructive operations on the canvas' `shape` in
`undo_last_line` and `reset_all_lines`, but former is dead code and latter
I don't know how to trigger. Thus I can't be sure un-highlighting will not
lead to visual glitches.

There are other potential fixes, e.g. checking in `selected_vertex`. I can
rework the patch, but then again, the fix is so straight forward that telling
me is probably more effort than just rewriting it.

See #750
See #605