### PR TITLE
Fix draw annotations error on windows

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -962,7 +962,7 @@ class MainWindow(QMainWindow, WindowMixin):
     def scroll_request(self, delta, orientation):
         units = - delta / (8 * 15)
         bar = self.scroll_bars[orientation]
-        bar.setValue(bar.value() + bar.singleStep() * units)
+        bar.setValue(int(bar.value() + bar.singleStep() * units))
 
     def set_zoom(self, value):
         self.actions.fitWidth.setChecked(False)

--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -525,12 +525,12 @@ class Canvas(QWidget):
             p.setPen(self.drawing_rect_color)
             brush = QBrush(Qt.BDiagPattern)
             p.setBrush(brush)
-            p.drawRect(left_top.x(), left_top.y(), rect_width, rect_height)
+            p.drawRect(int(left_top.x()), int(left_top.y()), int(rect_width), int(rect_height))
 
         if self.drawing() and not self.prev_point.isNull() and not self.out_of_pixmap(self.prev_point):
             p.setPen(QColor(0, 0, 0))
-            p.drawLine(self.prev_point.x(), 0, self.prev_point.x(), self.pixmap.height())
-            p.drawLine(0, self.prev_point.y(), self.pixmap.width(), self.prev_point.y())
+            p.drawLine(int(self.prev_point.x()), 0, int(self.prev_point.x()), int(self.pixmap.height()))
+            p.drawLine(0, int(self.prev_point.y()), int(self.pixmap.width()), int(self.prev_point.y()))
 
         self.setAutoFillBackground(True)
         if self.verified:

--- a/libs/shape.py
+++ b/libs/shape.py
@@ -128,7 +128,7 @@ class Shape(object):
                         self.label = ""
                     if min_y < min_y_label:
                         min_y += min_y_label
-                    painter.drawText(min_x, min_y, self.label)
+                    painter.drawText(int(min_x), int(min_y), self.label)
 
             if self.fill:
                 color = self.select_fill_color if self.selected else self.fill_color


### PR DESCRIPTION
related to #811

I forgot that I deleted all the files which I fixed before.

However, this fix works well so far.

While fixing it, I found other errors.

- when you try to push `d` right after you start the `labelimg`
   + IndexError: list index out of range

- when you try to delete after you `copy and paste`.
   + ValueError: list.remove(x): x not in list

I tried to change one line for the first error that I indicated, it seems to work.

Is it okay to submit another PR ?
