### PR TITLE
remove unused import statements

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -2,17 +2,12 @@
 # -*- coding: utf-8 -*-
 import argparse
 import codecs
-import distutils.spawn
 import os.path
 import platform
-import re
-import sys
-import subprocess
 import shutil
+import sys
 import webbrowser as wb
-
 from functools import partial
-from collections import defaultdict
 
 try:
     from PyQt5.QtGui import *
@@ -31,7 +26,6 @@ except ImportError:
 
 from libs.combobox import ComboBox
 from libs.default_label_combobox import DefaultLabelComboBox
-from libs.resources import *
 from libs.constants import *
 from libs.utils import *
 from libs.settings import Settings

--- a/libs/labelFile.py
+++ b/libs/labelFile.py
@@ -6,15 +6,13 @@ try:
 except ImportError:
     from PyQt4.QtGui import QImage
 
-from base64 import b64encode, b64decode
-from libs.pascal_voc_io import PascalVocWriter
-from libs.yolo_io import YOLOWriter
-from libs.pascal_voc_io import XML_EXT
-from libs.create_ml_io import CreateMLWriter
-from libs.create_ml_io import JSON_EXT
-from enum import Enum
 import os.path
-import sys
+from enum import Enum
+
+from libs.create_ml_io import CreateMLWriter
+from libs.pascal_voc_io import PascalVocWriter
+from libs.pascal_voc_io import XML_EXT
+from libs.yolo_io import YOLOWriter
 
 
 class LabelFileFormat(Enum):

--- a/libs/settings.py
+++ b/libs/settings.py
@@ -1,6 +1,5 @@
-import pickle
 import os
-import sys
+import pickle
 
 
 class Settings(object):

--- a/libs/yolo_io.py
+++ b/libs/yolo_io.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf8 -*-
-import sys
-import os
-from xml.etree import ElementTree
-from xml.etree.ElementTree import Element, SubElement
-from lxml import etree
 import codecs
+import os
+
 from libs.constants import DEFAULT_ENCODING
 
 TXT_EXT = '.txt'


### PR DESCRIPTION
To reduce clutter, all unused imports were removed. On the affected
files, imports were also reordered to be PEP8 sorted.