### PR TITLE
Fix delete selected shape error.

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -1054,7 +1054,10 @@ class MainWindow(QMainWindow, WindowMixin):
         self.canvas.setEnabled(False)
         if file_path is None:
             file_path = self.settings.get(SETTING_FILENAME)
-
+        #Deselect shape when loading new file
+        if self.canvas.selected_shape:
+            self.canvas.selected_shape.selected = False
+            self.canvas.selected_shape = None
         # Make sure that filePath is a regular python string, rather than QString
         file_path = ustr(file_path)
 


### PR DESCRIPTION
Delete Rectbox gives error if image without any shapes is loaded after image with shapes. 

canvas.selected_shape variable is not set to None when loading new file so if new file does not have any shape, previous file's selected_shape remains in the variable. delete_selected_shape function tries to remove previous file's selected_shape from empty shapes list.

Setting canvas.selected_shape to None at the start of load_file function solves the problem.