### PR TITLE
Fallback to predefined_classes in yolo_io

### DIFF
--- a/libs/yolo_io.py
+++ b/libs/yolo_io.py
@@ -94,7 +94,11 @@ class YoloReader:
 
         # print (file_path, self.class_list_path)
 
-        classes_file = open(self.class_list_path, 'r')
+        try:
+            classes_file = open(self.class_list_path, 'r')
+        except FileNotFoundError:
+            classes_file = open(os.path.join(os.path.dirname(__file__), "..", "data", "predefined_classes.txt"), 'r')
+            
         self.classes = classes_file.read().strip('\n').split('\n')
 
         # print (self.classes)


### PR DESCRIPTION
Currently the program stops if I try to open a folder which does not contain a classes.txt (in yolo mode). I think it could be a nice addition to just use the default predefined_classes.txt in case that no classes.txt can be found. The first save creates an exact copy of predefined_classes.txt inside the current folder as classes.txt. So it only really affects the first time a folder is opened.