### PR TITLE
actually find nearest point of shape

### DIFF
--- a/libs/shape.py
+++ b/libs/shape.py
@@ -153,10 +153,13 @@ class Shape(object):
             assert False, "unsupported vertex shape"
 
     def nearest_vertex(self, point, epsilon):
+        index = None
         for i, p in enumerate(self.points):
-            if distance(p - point) <= epsilon:
-                return i
-        return None
+            dist = distance(p - point)
+            if dist <= epsilon:
+                index = i
+                epsilon = dist
+        return index
 
     def contains_point(self, point):
         return self.make_path().contains(point)


### PR DESCRIPTION
For any shape with a dimension smaller than 2*epsilon, there can be
multiple potential points to select from. In practice this resulted
in e.g. the top right corner being highlighted when the cursor was
placed below the bottom right corner.