### PR TITLE
prefer selected shape when highlighting vertexes or shapes

### DIFF
--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -214,7 +214,8 @@ class Canvas(QWidget):
         # - Highlight vertex
         # Update shape/vertex fill and tooltip value accordingly.
         self.setToolTip("Image")
-        for shape in reversed([s for s in self.shapes if self.isVisible(s)]):
+        priority_list = self.shapes + ([self.selected_shape] if self.selected_shape else [])
+        for shape in reversed([s for s in priority_list if self.isVisible(s)]):
             # Look for a nearby vertex to highlight. If that fails,
             # check if we happen to be inside a shape.
             index = shape.nearest_vertex(pos, self.epsilon)


### PR DESCRIPTION
The use case is adjusting shapes by moving their vertexes, even if
they are adjacent or overlapping another shape. Currently always
the "later drawn" shape wins, making it impossible to adjust an
earlier shape without re-creating it. Adjusting existing shapes is
common for review scenarios.

I have experimented with preferring the highlighted shape, but
I found it finicky and less clear as to how the vertex preference
works. JOSM (and OpenStreetMap editor) also uses the "prefer
selected" approach and it works well there.