### PR TITLE
also clear highlights when loading a new image

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -1054,10 +1054,6 @@ class MainWindow(QMainWindow, WindowMixin):
         self.canvas.setEnabled(False)
         if file_path is None:
             file_path = self.settings.get(SETTING_FILENAME)
-        #Deselect shape when loading new file
-        if self.canvas.selected_shape:
-            self.canvas.selected_shape.selected = False
-            self.canvas.selected_shape = None
         # Make sure that filePath is a regular python string, rather than QString
         file_path = ustr(file_path)
 

--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -724,6 +724,10 @@ class Canvas(QWidget):
         QApplication.restoreOverrideCursor()
 
     def reset_state(self):
+        self.de_select_shape()
+        self.un_highlight()
+        self.selected_shape_copy = None
+
         self.restore_cursor()
         self.pixmap = None
         self.update()


### PR DESCRIPTION
This fixes a crash with the following steps to reproduce:
1. highlight a vertex or shape with the cursor
2. swap image using keyboard controls (i.e. press D)
3. left click on image without moving cursor. No shape may be below
   cursor.

What happens is that the canvas will emit a selection signal for
the shape from the previous image, which then can't be found anymore
in `shapes_to_items`, causing this error:

```
Traceback (most recent call last):
  File "/home/stefan/code/labelImg/./labelImg.py", line 806, in shape_selection_changed
    self.shapes_to_items[shape].setSelected(True)
KeyError: <libs.shape.Shape object at 0x7fdb281d06a0>
```

This builds upon the fix from #858, which fixed the issue for
selected shapes, but not highlights.