### PR TITLE
consider scale when panning image

### DIFF
--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -202,10 +202,9 @@ class Canvas(QWidget):
                         'Width: %d, Height: %d / X: %d; Y: %d' % (current_width, current_height, pos.x(), pos.y()))
             else:
                 # pan
-                delta_x = pos.x() - self.pan_initial_pos.x()
-                delta_y = pos.y() - self.pan_initial_pos.y()
-                self.scrollRequest.emit(delta_x, Qt.Horizontal)
-                self.scrollRequest.emit(delta_y, Qt.Vertical)
+                delta = ev.pos() - self.pan_initial_pos
+                self.scrollRequest.emit(delta.x(), Qt.Horizontal)
+                self.scrollRequest.emit(delta.y(), Qt.Vertical)
                 self.update()
             return
 
@@ -266,7 +265,7 @@ class Canvas(QWidget):
                 if selection is None:
                     # pan
                     QApplication.setOverrideCursor(QCursor(Qt.OpenHandCursor))
-                    self.pan_initial_pos = pos
+                    self.pan_initial_pos = ev.pos()
 
         elif ev.button() == Qt.RightButton and self.editing():
             self.select_shape_point(pos)


### PR DESCRIPTION
The previous variant calculates the delta by checking how many
"image pixels" the cursor was moved, and then emit an absolute
scrollbar move based on that. However, when zoomed in a single
image pixel can be multiple scroll bar units.

The effect was that panning a zoomed in image was very slow,
giving a rubber band kind of effect. Wiggling the mouse would emit
more deltas, eventually moving the image below the cursor again:
![labelimg_drag_slow](https://user-images.githubusercontent.com/307954/173221117-24bdd155-9b2f-41f8-b6a7-59ce06666dbf.gif)


This PR uses the absolute coordinates instead, which keeps the
image closer to the cursor. There is still a slight rubber band
effect, probably due to slight differences between painter and
scroll bar positions/units.

The result is that panning a zoomed in image feels less sluggish.

![labelimg_drag_fast](https://user-images.githubusercontent.com/307954/173221082-e9d05dcc-8612-461e-ae2f-29eb5feca6c4.gif)