### PR TITLE
move "OK" button below cursor when opening label dialog

### DIFF
--- a/libs/labelDialog.py
+++ b/libs/labelDialog.py
@@ -27,14 +27,15 @@ class LabelDialog(QDialog):
         completer.setModel(model)
         self.edit.setCompleter(completer)
 
-        layout = QVBoxLayout()
-        layout.addWidget(self.edit)
         self.button_box = bb = BB(BB.Ok | BB.Cancel, Qt.Horizontal, self)
         bb.button(BB.Ok).setIcon(new_icon('done'))
         bb.button(BB.Cancel).setIcon(new_icon('undo'))
         bb.accepted.connect(self.validate)
         bb.rejected.connect(self.reject)
-        layout.addWidget(bb)
+
+        layout = QVBoxLayout()
+        layout.addWidget(bb, alignment=Qt.AlignmentFlag.AlignLeft)
+        layout.addWidget(self.edit)
 
         if list_item is not None and len(list_item) > 0:
             self.list_widget = QListWidget(self)
@@ -64,6 +65,16 @@ class LabelDialog(QDialog):
         self.edit.setFocus(Qt.PopupFocusReason)
         if move:
             cursor_pos = QCursor.pos()
+
+            # move OK button below cursor
+            btn = self.button_box.buttons()[0]
+            self.adjustSize()
+            btn.adjustSize()
+            offset = btn.mapToGlobal(btn.pos()) - self.pos()
+            offset += QPoint(btn.size().width()/4, btn.size().height()/2)
+            cursor_pos.setX(max(0, cursor_pos.x() - offset.x()))
+            cursor_pos.setY(max(0, cursor_pos.y() - offset.y()))
+
             parent_bottom_right = self.parentWidget().geometry()
             max_x = parent_bottom_right.x() + parent_bottom_right.width() - self.sizeHint().width()
             max_y = parent_bottom_right.y() + parent_bottom_right.height() - self.sizeHint().height()


### PR DESCRIPTION
The intent for this change is to allow faster labeling when there
are streaks of the same label occasionally, but not consistently
enough to enable "default label" mode. With this PR the user can
simply click again to confirm the previous selection, without
having to aim for the OK button, or move either hand to the
ENTER key.

The alignment and position change of the buttons is for two reasons:
- it covers less of the drawn shape, easing verification of the
  label to be selected
- the alignment wasn't taken into account for offset calculation.
  It works if the dialog is shown, but that causes the dialog to
  briefly flicker in the old position. Presumably an `adjustSize`
  or similar is needed on more widgets, but I was unable to
  figure out which.