### PR TITLE
Fixed Issue 825: press Ctrl+D with none label, labelImg.py break down

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -813,6 +813,9 @@ class MainWindow(QMainWindow, WindowMixin):
         self.actions.shapeFillColor.setEnabled(selected)
 
     def add_label(self, shape):
+        if shape is None:
+            # print('add empty label')
+            return
         shape.paint_label = self.display_label_option.isChecked()
         item = HashableQListWidgetItem(shape.label)
         item.setFlags(item.flags() | Qt.ItemIsUserCheckable)


### PR DESCRIPTION
fixed when press Ctrl+D with none label, the labelImg.py break down