### PR TITLE
Solve Type Error in `scroll_request` method

### DIFF
--- a/labelImg.py
+++ b/labelImg.py
@@ -995,7 +995,7 @@ class MainWindow(QMainWindow, WindowMixin):
             self.canvas.reset_all_lines()
 
     def scroll_request(self, delta, orientation):
-        units = - delta / (8 * 15)
+        units = - delta // (8 * 15)
         bar = self.scroll_bars[orientation]
         bar.setValue(int(bar.value() + bar.singleStep() * units))
 


### PR DESCRIPTION
The following error occurs in `scroll_request` method:
```
Traceback (most recent call last):
  File "C:\Users\SohangChopra\AppData\Local\Programs\Python\Python311\Lib\site-packages\labelImg\labelImg.py", line 965, in scroll_request
    bar.setValue(bar.value() + bar.singleStep() * units)
TypeError: setValue(self, a0: int): argument 1 has unexpected type 'float'
```
This is because ` units = - delta / (8 * 15)` is a `float`, so `bar.value() + bar.singleStep() * units` is also coerced to a `float`. The solution is to use `//` (integer division) instead of `/`.